### PR TITLE
Dotnet6 pactnet302

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['3.1.x']
+        dotnet-version: ['6.0.x']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/
 obj/
 *.PID
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ restore:
 	dotnet restore src
 	dotnet restore tests
 
+run:
+	cd src && dotnet run
+
 ci: run_tests can_i_deploy $(DEPLOY_TARGET)
 
 start: server.PID

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The project uses a Makefile to simulate a very simple build pipeline with two st
 * Docker
 * A [PactFlow](https://pactflow.io) account
 * A [read/write API Token](https://docs.pactflow.io/#configuring-your-api-token) from your PactFlow account
-* .NET 3.1.201 installed. You can install it from here: https://docs.microsoft.com/en-us/dotnet/core/install/macos
+* .NET 6.x installed. You can install it from here: https://docs.microsoft.com/en-us/dotnet/core/install/macos
 
 ## Usage
 

--- a/src/provider.csproj
+++ b/src/provider.csproj
@@ -1,17 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <!-- <TargetFramework>netcoreapp2.0</TargetFramework> -->
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="3.1.7" />
-  </ItemGroup>
 
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />

--- a/tests/ProviderApiTests.cs
+++ b/tests/ProviderApiTests.cs
@@ -48,9 +48,8 @@ namespace tests
 
                 // Output verbose verification logs to the test output
                 Verbose = true,
-                PublishVerificationResults = true,
-                ProviderVersion = System.Environment.GetEnvironmentVariable("GIT_COMMIT")
-
+                PublishVerificationResults = !String.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("PACT_BROKER_PUBLISH_VERIFICATION_RESULTS")) ? true : false,
+                ProviderVersion = System.Environment.GetEnvironmentVariable("GIT_COMMIT"),
             };
 
             IPactVerifier pactVerifier = new PactVerifier(config);
@@ -59,13 +58,24 @@ namespace tests
                 .ProviderState($"{_pactServiceUri}/provider-states")
                 .ServiceProvider("pactflow-example-provider-dotnet", _providerUri);
 
-            if (pactUrl != "" && pactUrl != null) {
+            if (pactUrl != "" && pactUrl != null)
+            {
                 // Webhook path - verify the specific pact
-                pactVerifier.PactUri(pactUrl, new PactUriOptions(System.Environment.GetEnvironmentVariable("PACT_BROKER_TOKEN")));
-            } else {
+                pactVerifier.PactUri(pactUrl, !String.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("PACT_BROKER_TOKEN")) ? 
+                                        new PactUriOptions(System.Environment.GetEnvironmentVariable("PACT_BROKER_TOKEN")) : 
+                                            !String.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("PACT_BROKER_USERNAME")) ?
+                                                new PactUriOptions(System.Environment.GetEnvironmentVariable("PACT_BROKER_USERNAME"), 
+                                                    System.Environment.GetEnvironmentVariable("PACT_BROKER_PASSWORD")) : null);
+            }
+            else
+            {
                 // Standard verification path - run the
                 pactVerifier.PactBroker(System.Environment.GetEnvironmentVariable("PACT_BROKER_BASE_URL"),
-                    uriOptions: new PactUriOptions(System.Environment.GetEnvironmentVariable("PACT_BROKER_TOKEN")),
+                    uriOptions: !String.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("PACT_BROKER_TOKEN")) ? 
+                                        new PactUriOptions(System.Environment.GetEnvironmentVariable("PACT_BROKER_TOKEN")) : 
+                                            !String.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("PACT_BROKER_USERNAME")) ?
+                                                new PactUriOptions(System.Environment.GetEnvironmentVariable("PACT_BROKER_USERNAME"), 
+                                                    System.Environment.GetEnvironmentVariable("PACT_BROKER_PASSWORD")) : null,
                     consumerVersionTags: new List<string> { "master", "prod" });
             }
 

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="PactNet.OSX" Version="2.5.5" />
-    <PackageReference Include="PactNet.Windows" Version="2.5.5" />
-    <PackageReference Include="PactNet.Linux.x64" Version="2.5.5" />
+    <PackageReference Include="PactNet.OSX" Version="3.0.2" />
+    <PackageReference Include="PactNet.Windows" Version="3.0.2" />
+    <PackageReference Include="PactNet.Linux.x64" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,20 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>netcoreapp2.0</TargetFramework> -->
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="PactNet.OSX" Version="2.5.5" />
     <PackageReference Include="PactNet.Windows" Version="2.5.5" />
     <PackageReference Include="PactNet.Linux.x64" Version="2.5.5" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="3.1.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates to

- .NET 6.x
- PactNet 3.0.2 (latest ruby package)

In preparation for updating these repos to PactNet 4.x

Will possibly create a spin off branch called 3.x for legacy reasons

Bonus points

- Have also allowed for the provider side verification to take place
  - Locally via `PACT_URL`, but not passing in a token, (so that you can run both repos on the machine `PACT_URL=/Users/saf/dev/DIUS/example-consumer-dotnet/pacts/pactflow-example-consumer-dotnet-pactflow-example-provider-dotnet.json make test` without it bailing if you don't have env vars set
  - Use `PACT_BROKER_TOKEN` if set
  - otherwise see if `PACT_BROKER_USERNAME` is set and use that along with `PACT_BROKER_PASSWORD` or assume there are no credentials on the broker.
  
 This allows you a user to
 - verify both applications cloned locally, without a broker
 - verify both applications with pacts pushed to an OSS Pact broker
 - verify both applications with pacts pushed to a PactFlow Broker