### PR TITLE
fix: quote boolean env var in launch settings

### DIFF
--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -7,7 +7,7 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
                 "ASPNETCORE_URLS": "http://localhost:9000/",
-                "PACT_PROVIDER_SHOULD_THROW_404": false
+                "PACT_PROVIDER_SHOULD_THROW_404": "false"
             }
         }
     }


### PR DESCRIPTION
## Problem

`src/Properties/launchSettings.json` set a launch profile environment variable to a bare JSON boolean:

```json
"PACT_PROVIDER_SHOULD_THROW_404": false
```

Values in `environmentVariables` must be strings. Recent .NET SDK builds reject non-string values rather than coercing them, and the failure is not scoped to the offending key — the **entire `Development` profile is discarded**. That takes `ASPNETCORE_URLS` with it, so the provider binds to the default port 5000 while Pact verification targets port 9000:

```
An error was encountered when reading 'src/Properties/launchSettings.json': The JSON value could not
be converted to System.String. Path: $.environmentVariables.PACT_PROVIDER_SHOULD_THROW_404
...
Now listening on: http://localhost:5000
```

Verification then fails with `error sending request for url (http://localhost:9000/products)`.

The state-change handler on port 9001 is hosted by the test process itself, which is why it kept responding normally and made this present as an application failure rather than a configuration one.

## Why now

The file is unchanged since the initial commit (bb7e88b), yet master passed on 2026-03-06 against the same `net10.0` target. The stricter parsing arrived with a newer 10.0.x SDK resolved at run time by `setup-dotnet`, so this began failing without any change landing in the repo.

This is the sole cause of the red `test (10.0.x)` job on master and on all five open Renovate PRs (#49, #50, #51, #52, #53) — every failing job shares an identical signature: parse error, bind to :5000, `Failed: 1, Passed: 0`. None of those updates introduced a defect; they inherit a broken baseline. Rebasing them once this lands should clear them.

## Verification

Reproduced the original failure locally on SDK 10.0.301, then confirmed the fix:

- Launch profile now loads; app binds to `http://localhost:9000`
- `GET localhost:9000/products` returns HTTP 200 with the expected payload — the exact request the verifier could not reach

The full broker-backed suite was not run locally, as it requires `PACT_BROKER_BASE_URL` / `PACT_BROKER_TOKEN`. CI covers that.

## Note

`PACT_PROVIDER_SHOULD_THROW_404` is not read anywhere in this repo and is undocumented in the README, so it is currently dead configuration. It is retained here because sibling pactflow example providers use it as a "break the provider" demo hook, and quoting is the minimal change. Happy to remove it instead if preferred.